### PR TITLE
Fix SaveToJson<T> method in DataAccess

### DIFF
--- a/TutorLizard.BusinessLogic/Data/DataAccess.cs
+++ b/TutorLizard.BusinessLogic/Data/DataAccess.cs
@@ -315,8 +315,13 @@ public class DataAccess : IUserIdentityDataAccess, IStudentDataAccess, ITutorDat
     #region Save to Json
     private void SaveToJson<T>(string path, T data)
     {
-        var filePath = Path.Combine(path.Split('/'));
-        string fullPath = Path.Combine(AppContext.BaseDirectory, filePath);
+        string filePath = Path.Combine(path.Split('/'));
+        string fullPath;
+        if (Path.IsPathRooted(filePath))
+            fullPath = filePath;
+        else
+            fullPath = Path.Combine(AppContext.BaseDirectory, filePath);
+
         string? directoryPath = Path.GetDirectoryName(fullPath);
 
         var jsonData = JsonSerializer.Serialize(data, new JsonSerializerOptions

--- a/TutorLizard.BusinessLogic/Data/DataAccess.cs
+++ b/TutorLizard.BusinessLogic/Data/DataAccess.cs
@@ -268,13 +268,19 @@ public class DataAccess : IUserIdentityDataAccess, IStudentDataAccess, ITutorDat
         LoadAdRequestsFromJson();
     }
 
-    private List<T> LoadFromJson<T>(string Path)
+    private List<T> LoadFromJson<T>(string path)
     {
-        var filePath = $@"{Path}";
-        if (!File.Exists(filePath))
+        string filePath = Path.Combine(path.Split('/'));
+        string fullPath;
+        if (Path.IsPathRooted(filePath))
+            fullPath = filePath;
+        else
+            fullPath = Path.Combine(AppContext.BaseDirectory, filePath);
+
+        if (!File.Exists(fullPath))
             return new List<T>();
 
-        var jsonData = File.ReadAllText(filePath);
+        var jsonData = File.ReadAllText(fullPath);
 
         var outputList = JsonSerializer.Deserialize<List<T>>(jsonData, new JsonSerializerOptions
         {

--- a/TutorLizard.BusinessLogic/Data/DataAccess.cs
+++ b/TutorLizard.BusinessLogic/Data/DataAccess.cs
@@ -313,15 +313,24 @@ public class DataAccess : IUserIdentityDataAccess, IStudentDataAccess, ITutorDat
     #endregion
 
     #region Save to Json
-    private void SaveToJson<T>(string Path, T data)
+    private void SaveToJson<T>(string path, T data)
     {
-        var filePath = $@"{Path}";
+        var filePath = Path.Combine(path.Split('/'));
 
         var jsonData = JsonSerializer.Serialize(data, new JsonSerializerOptions
         {
             WriteIndented = true,
         });
-        File.WriteAllText(filePath, jsonData);
+
+        var current = AppContext.BaseDirectory;
+
+        string fullPath = Path.Combine(current, filePath);
+        string? directoryPath = Path.GetDirectoryName(fullPath);
+
+        if (directoryPath is not null && Directory.Exists(directoryPath) == false)
+            Directory.CreateDirectory(directoryPath);
+
+        File.WriteAllText(fullPath, jsonData);
     }
 
     private void SaveUsersToJson()

--- a/TutorLizard.BusinessLogic/Data/DataAccess.cs
+++ b/TutorLizard.BusinessLogic/Data/DataAccess.cs
@@ -316,16 +316,13 @@ public class DataAccess : IUserIdentityDataAccess, IStudentDataAccess, ITutorDat
     private void SaveToJson<T>(string path, T data)
     {
         var filePath = Path.Combine(path.Split('/'));
+        string fullPath = Path.Combine(AppContext.BaseDirectory, filePath);
+        string? directoryPath = Path.GetDirectoryName(fullPath);
 
         var jsonData = JsonSerializer.Serialize(data, new JsonSerializerOptions
         {
             WriteIndented = true,
         });
-
-        var current = AppContext.BaseDirectory;
-
-        string fullPath = Path.Combine(current, filePath);
-        string? directoryPath = Path.GetDirectoryName(fullPath);
 
         if (directoryPath is not null && Directory.Exists(directoryPath) == false)
             Directory.CreateDirectory(directoryPath);


### PR DESCRIPTION
The method threw exception when the save directory didn't exist, so I added check if exists and if it doesn't, the method creates it before trying to write to a file in it. I also noticed that when running a web app, relative paths point to source code directory instead of the running directory, so I get the actual running directory from AppContext.BaseDirectory. The paths we had specified with '/'s didn't work with the Path methods, so I had to split the path and recombine it.