### PR TITLE
Feature/JA-67 Add DTO classes

### DIFF
--- a/TutorLizard.BusinessLogic/Extensions/DtoExtensions.cs
+++ b/TutorLizard.BusinessLogic/Extensions/DtoExtensions.cs
@@ -1,0 +1,13 @@
+﻿using TutorLizard.BusinessLogic.Models;
+using TutorLizard.BusinessLogic.Models.DTOs;
+
+namespace TutorLizard.BusinessLogic.Extensions;
+public static class DtoExtensions
+{
+    public static AdDto ToDto(this Ad ad) => new AdDto(ad);
+    public static AdRequestDto ToDto(this AdRequest adRequest) => new AdRequestDto(adRequest);
+    public static CategoryDto ToDto(this Category category) => new CategoryDto(category);
+    public static ScheduleItemDto ToDto(this ScheduleItem scheduleItem) => new ScheduleItemDto(scheduleItem);
+    public static ScheduleItemRequestDto ToDto(this ScheduleItemRequest scheduleItemRequest) => new ScheduleItemRequestDto(scheduleItemRequest);
+    public static UserDto ToDto(this User user) => new UserDto(user);
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/AdDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/AdDto.cs
@@ -1,0 +1,46 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class AdDto
+{
+    public int Id { get; set; }
+    public int TutorId { get; set; }
+
+    [Required(ErrorMessage = "Please provide subject!")]
+    [StringLength(25)]
+    public string Subject { get; set; }
+
+    [Required(ErrorMessage = "Please provide title!")]
+    [StringLength(25)]
+    public string Title { get; set; }
+
+    [Required(ErrorMessage = "Please provide description!")]
+    [StringLength(250)]
+    public string Description { get; set; }
+
+    [Display(Name = "Category")]
+    [Required(ErrorMessage = "Please provide category!")]
+    public int CategoryId { get; set; }
+
+    [Required(ErrorMessage = "Please provide price!")]
+    [Range(0, double.MaxValue, ErrorMessage = "The price must be greater than 0!")]
+    public double Price { get; set; }
+
+    [Required(ErrorMessage = "Please provide location!")]
+    [StringLength(25)]
+    public string Location { get; set; }
+    public bool IsRemote { get; set; }
+
+    public AdDto(Ad ad)
+    {
+        Id = ad.Id;
+        TutorId = ad.TutorId;
+        Subject = ad.Subject;
+        Title = ad.Title;
+        Description = ad.Description;
+        CategoryId = ad.CategoryId;
+        Price = ad.Price;
+        Location = ad.Location;
+        IsRemote = ad.IsRemote;
+    }
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/AdRequestDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/AdRequestDto.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class AdRequestDto
+{
+    public int Id { get; set; }
+
+    [Required(ErrorMessage = "Please provide Ad Id!")]
+    [Range(0, int.MaxValue, ErrorMessage = "Ad Id must be greater than 0!")]
+    public int AdId { get; set; }
+
+    [Required(ErrorMessage = "Please provide your id!")]
+    [Range(0, int.MaxValue, ErrorMessage = "Id must be greater than 0!")]
+    public int StudentId { get; set; }
+    public bool IsAccepted { get; set; }
+
+    [Required(ErrorMessage = "Please write a message!")]
+    [MaxLength(150)]
+    public string Message { get; set; }
+    public string? ReplyMessage { get; set; }
+    public DateTime ReviewDate { get; set; }
+    public bool IsRemote { get; set; }
+
+    public AdRequestDto(AdRequest adRequest)
+    {
+        Id = adRequest.Id;
+        AdId = adRequest.AdId;
+        StudentId = adRequest.StudentId;
+        IsAccepted = adRequest.IsAccepted;
+        Message = adRequest.Message;
+        ReplyMessage = adRequest.ReplyMessage;
+        ReviewDate = adRequest.ReviewDate;
+        IsRemote = adRequest.IsRemote;
+    }
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/CategoryDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/CategoryDto.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class CategoryDto
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [MaxLength(20)]
+    public string Name { get; set; }
+    public string? Description { get; set; }
+
+    public CategoryDto(Category category)
+    {
+        Id = category.Id;
+        Name = category.Name;
+        Description = category.Description;
+    }
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/ScheduleItemDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/ScheduleItemDto.cs
@@ -1,0 +1,14 @@
+﻿namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class ScheduleItemDto
+{
+    public int Id { get; set; }
+    public int AdId { get; set; }
+    public DateTime DateTime { get; set; }
+
+    public ScheduleItemDto(ScheduleItem scheduleItem)
+    {
+        Id = scheduleItem.Id;
+        AdId = scheduleItem.AdId;
+        DateTime = scheduleItem.DateTime;
+    }
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/ScheduleItemRequestDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/ScheduleItemRequestDto.cs
@@ -1,0 +1,18 @@
+﻿namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class ScheduleItemRequestDto
+{
+    public int Id { get; set; }
+    public int ScheduleItemId { get; set; }
+    public int StudentId { get; set; }
+    public bool IsAccepted { get; set; }
+    public bool IsRemote { get; set; }
+
+    public ScheduleItemRequestDto(ScheduleItemRequest scheduleItemRequest)
+    {
+        Id = scheduleItemRequest.Id;
+        ScheduleItemId = scheduleItemRequest.ScheduleItemId;
+        StudentId = scheduleItemRequest.StudentId;
+        IsAccepted = scheduleItemRequest.IsAccepted;
+        IsRemote = scheduleItemRequest.IsRemote;
+    }
+}

--- a/TutorLizard.BusinessLogic/Models/DTOs/UserDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/UserDto.cs
@@ -1,4 +1,33 @@
-﻿namespace TutorLizard.BusinessLogic.Models.DTOs;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TutorLizard.BusinessLogic.Models.DTOs;
 public class UserDto
 {
+    public int Id { get; set; }
+
+    [Required(ErrorMessage = "Podaj nazwę użytkownika.")]
+    [Display(Name = "Nazwa użytkownika")]
+    [MinLength(5, ErrorMessage = "Minimalna długość: 5 znaków")]
+    [MaxLength(20, ErrorMessage = "Maksymalna długość: 20 znaków")]
+    public string Name { get; set; }
+
+    [Display(Name = "Typ użytkownika")]
+    public UserType UserType { get; set; }
+
+    [Required(ErrorMessage = "Podaj adres email.")]
+    [EmailAddress(ErrorMessage = "Podaj prawidłowy adres email.")]
+    [Display(Name = "Adres email")]
+    public string Email { get; set; }
+
+    [Display(Name = "Data rejestracji")]
+    public DateTime DateCreated { get; set; } = DateTime.Now;
+
+    public UserDto(User user)
+    {
+        Id = user.Id;
+        Name = user.Name;
+        UserType = user.UserType;
+        Email = user.Email;
+        DateCreated = user.DateCreated;
+    }
 }

--- a/TutorLizard.BusinessLogic/Models/DTOs/UserDto.cs
+++ b/TutorLizard.BusinessLogic/Models/DTOs/UserDto.cs
@@ -1,0 +1,4 @@
+﻿namespace TutorLizard.BusinessLogic.Models.DTOs;
+public class UserDto
+{
+}


### PR DESCRIPTION
I added a DTO for each of our model classes.
Right now, they are almost the same as models in terms of their properties. The only property that is not copied when creating a new DTO based on model, is `PasswordHash` in `UserDto`.
You can create DTO by instantiating it and passing the model in the constructor:
```
User user = _userRepository.GetUserById(userId);
UserDto userDto = new(user);
```

I decided to put the mapping logic in the constructor of DTOs, so that when we modify a DTO, we don't have to navigate to some other file to change way its mapped from the model.
However, I think that having an extension method that transforms a model into a DTO would be convenient, so I added `DtoExtensions` static class that adds a `ToDto()` method to each model, that just returns a new instance of its corresponding DTO. These methods are so basic, I don't forsee any need to modify them in the future.
Now, the above can be simplified to:
```
UserDto userDto = _userRepository.GetUserById(userId).ToDto();
```
And in case of a collection:
```
List<CategoryDto> categories = _categoryRepository
    .GetAllCategories()
    .Select(c => c.ToDto())
    .ToList();
```